### PR TITLE
test: agregar pruebas de consulta y mantenimiento de proyectos

### DIFF
--- a/backend-springboot/src/test/java/com/hasbi/taskManager/controller/ProjectControllerTest.java
+++ b/backend-springboot/src/test/java/com/hasbi/taskManager/controller/ProjectControllerTest.java
@@ -1,0 +1,103 @@
+package com.hasbi.taskManager.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hasbi.taskManager.dto.ProjectDto;
+import com.hasbi.taskManager.service.ProjectService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProjectController.class)
+class ProjectControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ProjectService projectService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void shouldReturnAllProjects() throws Exception {
+        // Arrange
+        ProjectDto project = new ProjectDto(1L, "Proyecto 1", "Descripción 1");
+
+        when(projectService.getAllProjects()).thenReturn(List.of(project));
+
+        // Act + Assert
+        mockMvc.perform(get("/projects/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].name").value("Proyecto 1"))
+                .andExpect(jsonPath("$[0].description").value("Descripción 1"));
+
+        verify(projectService).getAllProjects();
+    }
+
+    @Test
+    void shouldReturnProjectById() throws Exception {
+        // Arrange
+        ProjectDto project = new ProjectDto(1L, "Proyecto 1", "Descripción 1");
+
+        when(projectService.getProjectById(1L)).thenReturn(project);
+
+        // Act + Assert
+        mockMvc.perform(get("/projects/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.name").value("Proyecto 1"))
+                .andExpect(jsonPath("$.description").value("Descripción 1"));
+
+        verify(projectService).getProjectById(1L);
+    }
+
+    @Test
+    void shouldUpdateProject() throws Exception {
+        // Arrange
+        ProjectDto request = new ProjectDto(null, "Proyecto actualizado", "Descripción actualizada");
+        ProjectDto response = new ProjectDto(1L, "Proyecto actualizado", "Descripción actualizada");
+
+        when(projectService.updateProject(Mockito.eq(1L), Mockito.any(ProjectDto.class)))
+                .thenReturn(response);
+
+        // Act + Assert
+        mockMvc.perform(put("/projects/update/1")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.name").value("Proyecto actualizado"))
+                .andExpect(jsonPath("$.description").value("Descripción actualizada"));
+
+        verify(projectService).updateProject(Mockito.eq(1L), Mockito.any(ProjectDto.class));
+    }
+
+    @Test
+    void shouldDeleteProject() throws Exception {
+        // Arrange
+        doNothing().when(projectService).deleteProject(1L);
+
+        // Act + Assert
+        mockMvc.perform(delete("/projects/delete/1"))
+                .andExpect(status().isNoContent());
+
+        verify(projectService).deleteProject(1L);
+    }
+}

--- a/backend-springboot/src/test/java/com/hasbi/taskManager/entity/ProjectTest.java
+++ b/backend-springboot/src/test/java/com/hasbi/taskManager/entity/ProjectTest.java
@@ -1,0 +1,35 @@
+package com.hasbi.taskManager.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProjectTest {
+
+    @Test
+    void shouldAssignNameToProject() {
+        Project project = new Project();
+
+        project.setName("Proyecto 1");
+
+        assertThat(project.getName()).isEqualTo("Proyecto 1");
+    }
+
+    @Test
+    void shouldAssignDescriptionToProject() {
+        Project project = new Project();
+
+        project.setDescription("Descripción 1");
+
+        assertThat(project.getDescription()).isEqualTo("Descripción 1");
+    }
+
+    @Test
+    void shouldAssignIdToProject() {
+        Project project = new Project();
+
+        project.setId(1L);
+
+        assertThat(project.getId()).isEqualTo(1L);
+    }
+}

--- a/backend-springboot/src/test/java/com/hasbi/taskManager/repository/ProjectRepositoryTest.java
+++ b/backend-springboot/src/test/java/com/hasbi/taskManager/repository/ProjectRepositoryTest.java
@@ -27,6 +27,18 @@ class ProjectRepositoryTest {
     private ProjectRepository projectRepository;
 
     @Test
+    void shouldSaveProjectAndAssignId() {
+        Project project = new Project();
+        project.setName("Proyecto 1");
+        project.setDescription("Descripción 1");
+
+        Project savedProject = projectRepository.save(project);
+
+        assertThat(savedProject.getId()).isNotNull();
+        assertThat(savedProject.getName()).isEqualTo("Proyecto 1");
+    }
+
+    @Test
     void shouldFindProjectById() {
         Project project = new Project();
         project.setName("Proyecto Test");

--- a/backend-springboot/src/test/java/com/hasbi/taskManager/repository/ProjectRepositoryTest.java
+++ b/backend-springboot/src/test/java/com/hasbi/taskManager/repository/ProjectRepositoryTest.java
@@ -1,0 +1,111 @@
+package com.hasbi.taskManager.repository;
+
+import com.hasbi.taskManager.entity.Project;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect"
+})
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+class ProjectRepositoryTest {
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Test
+    void shouldFindProjectById() {
+        Project project = new Project();
+        project.setName("Proyecto Test");
+        project.setDescription("Descripción Test");
+
+        Project savedProject = projectRepository.save(project);
+
+        Optional<Project> result = projectRepository.findById(savedProject.getId());
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getName()).isEqualTo("Proyecto Test");
+        assertThat(result.get().getDescription()).isEqualTo("Descripción Test");
+    }
+
+    @Test
+    void shouldFindAllProjects() {
+        Project project1 = new Project();
+        project1.setName("Proyecto 1");
+        project1.setDescription("Descripción 1");
+
+        Project project2 = new Project();
+        project2.setName("Proyecto 2");
+        project2.setDescription("Descripción 2");
+
+        projectRepository.save(project1);
+        projectRepository.save(project2);
+
+        List<Project> projects = projectRepository.findAll();
+
+        assertThat(projects).hasSize(2);
+        assertThat(projects).extracting(Project::getName)
+                .containsExactlyInAnyOrder("Proyecto 1", "Proyecto 2");
+    }
+
+    @Test
+    void shouldUpdateProject() {
+        Project project = new Project();
+        project.setName("Nombre original");
+        project.setDescription("Descripción original");
+
+        Project savedProject = projectRepository.save(project);
+
+        savedProject.setName("Nombre actualizado");
+        savedProject.setDescription("Descripción actualizada");
+        Project updatedProject = projectRepository.save(savedProject);
+
+        Optional<Project> result = projectRepository.findById(updatedProject.getId());
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getName()).isEqualTo("Nombre actualizado");
+        assertThat(result.get().getDescription()).isEqualTo("Descripción actualizada");
+    }
+
+    @Test
+    void shouldDeleteProject() {
+        Project project = new Project();
+        project.setName("Proyecto a eliminar");
+        project.setDescription("Descripción");
+
+        Project savedProject = projectRepository.save(project);
+        Long projectId = savedProject.getId();
+
+        projectRepository.deleteById(projectId);
+
+        Optional<Project> result = projectRepository.findById(projectId);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldReturnTrueWhenProjectExistsById() {
+        Project project = new Project();
+        project.setName("Proyecto existente");
+        project.setDescription("Descripción");
+
+        Project savedProject = projectRepository.save(project);
+
+        boolean exists = projectRepository.existsById(savedProject.getId());
+
+        assertThat(exists).isTrue();
+    }
+}

--- a/backend-springboot/src/test/java/com/hasbi/taskManager/service/ProjectServiceTest.java
+++ b/backend-springboot/src/test/java/com/hasbi/taskManager/service/ProjectServiceTest.java
@@ -48,20 +48,26 @@ class ProjectServiceTest {
         ProjectDto result = projectService.createProject(projectDto);
 
         assertNotNull(result);
+        assertEquals(projectDto.getId(), result.getId());
         assertEquals(projectDto.getName(), result.getName());
         verify(projectRepository).save(project);
     }
 
     @Test
     void getAllProjects_ShouldReturnListOfDtos() {
-        List<Project> projects = Arrays.asList(project);
+        Project project2 = new Project(2L, "Test Project 2", "Test Description 2");
+        ProjectDto projectDto2 = new ProjectDto(2L, "Test Project 2", "Test Description 2");
+        List<Project> projects = Arrays.asList(project, project2);
+
         when(projectRepository.findAll()).thenReturn(projects);
         when(projectMapper.toDto(project)).thenReturn(projectDto);
+        when(projectMapper.toDto(project2)).thenReturn(projectDto2);
 
         List<ProjectDto> result = projectService.getAllProjects();
 
-        assertEquals(1, result.size());
+        assertEquals(2, result.size());
         assertEquals(projectDto.getName(), result.get(0).getName());
+        assertEquals(projectDto2.getName(), result.get(1).getName());
     }
 
     @Test
@@ -77,9 +83,9 @@ class ProjectServiceTest {
 
     @Test
     void getProjectById_WhenNotFound_ShouldThrowException() {
-        when(projectRepository.findById(1L)).thenReturn(Optional.empty());
+        when(projectRepository.findById(999L)).thenReturn(Optional.empty());
 
-        assertThrows(ResourceNotFoundException.class, () -> projectService.getProjectById(1L));
+        assertThrows(ResourceNotFoundException.class, () -> projectService.getProjectById(999L));
     }
 
     @Test
@@ -116,8 +122,8 @@ class ProjectServiceTest {
 
     @Test
     void deleteProject_WhenNotExists_ShouldThrowException() {
-        when(projectRepository.existsById(1L)).thenReturn(false);
+        when(projectRepository.existsById(999L)).thenReturn(false);
 
-        assertThrows(ResourceNotFoundException.class, () -> projectService.deleteProject(1L));
+        assertThrows(ResourceNotFoundException.class, () -> projectService.deleteProject(999L));
     }
 }

--- a/frontend-reactjs/package.json
+++ b/frontend-reactjs/package.json
@@ -38,5 +38,14 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "^react-router-dom$": "<rootDir>/node_modules/react-router-dom/dist/index.js",
+      "^react-router$": "<rootDir>/node_modules/react-router/dist/development/index.js"
+    },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(axios|react-router-dom|react-router)/)"
+    ]
   }
 }

--- a/frontend-reactjs/src/api/projects.test.js
+++ b/frontend-reactjs/src/api/projects.test.js
@@ -1,0 +1,64 @@
+jest.mock('./api', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+import api from './api';
+import {
+  fetchProjects,
+  fetchProjectById,
+  updateProject,
+  deleteProject,
+} from './projects';
+
+describe('projects API - consulta y mantenimiento', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetchProjects debe consultar todos los proyectos', async () => {
+    const mockResponse = { data: [{ id: 1, name: 'Proyecto 1' }] };
+    api.get.mockResolvedValue(mockResponse);
+
+    const result = await fetchProjects();
+
+    expect(api.get).toHaveBeenCalledWith('/projects/all');
+    expect(result).toEqual(mockResponse);
+  });
+
+  test('fetchProjectById debe consultar un proyecto por id', async () => {
+    const mockResponse = { data: { id: 1, name: 'Proyecto 1' } };
+    api.get.mockResolvedValue(mockResponse);
+
+    const result = await fetchProjectById(1);
+
+    expect(api.get).toHaveBeenCalledWith('/projects/1');
+    expect(result).toEqual(mockResponse);
+  });
+
+  test('updateProject debe actualizar un proyecto existente', async () => {
+    const payload = { name: 'Proyecto actualizado', description: 'Nueva descripción' };
+    const mockResponse = { data: { id: 1, ...payload } };
+    api.put.mockResolvedValue(mockResponse);
+
+    const result = await updateProject(1, payload);
+
+    expect(api.put).toHaveBeenCalledWith('/projects/update/1', payload);
+    expect(result).toEqual(mockResponse);
+  });
+
+  test('deleteProject debe eliminar un proyecto', async () => {
+    const mockResponse = { data: null };
+    api.delete.mockResolvedValue(mockResponse);
+
+    const result = await deleteProject(1);
+
+    expect(api.delete).toHaveBeenCalledWith('/projects/delete/1');
+    expect(result).toEqual(mockResponse);
+  });
+});

--- a/frontend-reactjs/src/components/projects/ProjectForm.test.js
+++ b/frontend-reactjs/src/components/projects/ProjectForm.test.js
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ProjectForm from './ProjectForm';
+
+describe('ProjectForm - mantenimiento de proyectos', () => {
+  const onSubmit = jest.fn();
+  const onCancel = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('debe cargar datos iniciales al editar un proyecto', () => {
+    render(
+      <ProjectForm
+        initialData={{ id: 1, name: 'Proyecto existente', description: 'Descripción existente' }}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+      />
+    );
+
+    expect(screen.getByDisplayValue('Proyecto existente')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Descripción existente')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument();
+  });
+
+  test('debe enviar los datos actualizados al mantener un proyecto', () => {
+    render(
+      <ProjectForm
+        initialData={{ id: 1, name: 'Proyecto existente', description: 'Descripción existente' }}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Project Name'), {
+      target: { value: 'Proyecto actualizado' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Project Description'), {
+      target: { value: 'Descripción actualizada' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      name: 'Proyecto actualizado',
+      description: 'Descripción actualizada',
+    });
+  });
+
+  test('debe cancelar la edición de un proyecto', () => {
+    render(
+      <ProjectForm
+        initialData={{ id: 1, name: 'Proyecto existente', description: 'Descripción existente' }}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend-reactjs/src/components/projects/ProjectsList.js
+++ b/frontend-reactjs/src/components/projects/ProjectsList.js
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from 'react';
-import { fetchProjects } from '../../api/projects';
+import React from 'react';
 import { FiEdit, FiTrash2, FiEye} from 'react-icons/fi';
 
 const ProjectsList = ({ projects, onSelect, onEdit, onDelete }) => {

--- a/frontend-reactjs/src/components/projects/ProjectsList.test.js
+++ b/frontend-reactjs/src/components/projects/ProjectsList.test.js
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ProjectsList from './ProjectsList';
+
+describe('ProjectsList - consulta de proyectos', () => {
+  const projects = [
+    { id: 1, name: 'Proyecto Alpha', description: 'Descripción Alpha' },
+    { id: 2, name: 'Proyecto Beta', description: 'Descripción Beta' },
+  ];
+
+  const onSelect = jest.fn();
+  const onEdit = jest.fn();
+  const onDelete = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('debe renderizar la lista de proyectos consultados', () => {
+    render(
+      <ProjectsList
+        projects={projects}
+        onSelect={onSelect}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />
+    );
+
+    expect(screen.getByText('Proyecto Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Proyecto Beta')).toBeInTheDocument();
+    expect(screen.getByText('Descripción Alpha')).toBeInTheDocument();
+  });
+
+  test('debe mostrar mensaje cuando no hay proyectos', () => {
+    render(
+      <ProjectsList
+        projects={[]}
+        onSelect={onSelect}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />
+    );
+
+    expect(screen.getByText('No projects found.')).toBeInTheDocument();
+  });
+
+  test('debe permitir seleccionar un proyecto para consultar sus tareas', () => {
+    render(
+      <ProjectsList
+        projects={projects}
+        onSelect={onSelect}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Proyecto Alpha'));
+
+    expect(onSelect).toHaveBeenCalledWith(1);
+  });
+
+  test('debe invocar onEdit al mantener un proyecto', () => {
+    render(
+      <ProjectsList
+        projects={projects}
+        onSelect={onSelect}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />
+    );
+
+    fireEvent.click(screen.getAllByTitle('Edit')[0]);
+
+    expect(onEdit).toHaveBeenCalledWith(projects[0]);
+  });
+
+  test('debe invocar onDelete al eliminar un proyecto', () => {
+    render(
+      <ProjectsList
+        projects={projects}
+        onSelect={onSelect}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />
+    );
+
+    fireEvent.click(screen.getAllByTitle('Delete')[0]);
+
+    expect(onDelete).toHaveBeenCalledWith(projects[0]);
+  });
+});

--- a/frontend-reactjs/src/pages/ProjectsPage.test.js
+++ b/frontend-reactjs/src/pages/ProjectsPage.test.js
@@ -1,0 +1,112 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import ProjectsPage from './ProjectsPage';
+import * as projectsApi from '../api/projects';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  MemoryRouter: ({ children }) => children,
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../api/projects');
+
+const projects = [
+  { id: 1, name: 'Proyecto Alpha', description: 'Descripción Alpha' },
+  { id: 2, name: 'Proyecto Beta', description: 'Descripción Beta' },
+];
+
+const renderProjectsPage = () => render(<ProjectsPage />);
+
+describe('ProjectsPage - consulta y mantenimiento de proyectos', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    projectsApi.fetchProjects.mockResolvedValue({ data: projects });
+    projectsApi.updateProject.mockResolvedValue({ data: projects[0] });
+    projectsApi.deleteProject.mockResolvedValue({});
+  });
+
+  test('debe consultar y mostrar los proyectos al cargar la página', async () => {
+    renderProjectsPage();
+
+    await waitFor(() => {
+      expect(projectsApi.fetchProjects).toHaveBeenCalledTimes(1);
+    });
+
+    expect(await screen.findByText('Proyecto Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Proyecto Beta')).toBeInTheDocument();
+  });
+
+  test('debe navegar al detalle de tareas al seleccionar un proyecto', async () => {
+    renderProjectsPage();
+
+    await screen.findByText('Proyecto Alpha');
+    fireEvent.click(screen.getByText('Proyecto Alpha'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/projects/1/tasks');
+  });
+
+  test('debe abrir el formulario de edición para mantener un proyecto', async () => {
+    renderProjectsPage();
+
+    await screen.findByText('Proyecto Alpha');
+    fireEvent.click(screen.getAllByTitle('Edit')[0]);
+
+    expect(screen.getByText('Edit Project')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Proyecto Alpha')).toBeInTheDocument();
+  });
+
+  test('debe actualizar un proyecto y recargar la consulta', async () => {
+    renderProjectsPage();
+
+    await screen.findByText('Proyecto Alpha');
+    fireEvent.click(screen.getAllByTitle('Edit')[0]);
+
+    fireEvent.change(screen.getByPlaceholderText('Project Name'), {
+      target: { value: 'Proyecto Alpha actualizado' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+
+    await waitFor(() => {
+      expect(projectsApi.updateProject).toHaveBeenCalledWith(1, {
+        name: 'Proyecto Alpha actualizado',
+        description: 'Descripción Alpha',
+      });
+    });
+
+    expect(projectsApi.fetchProjects).toHaveBeenCalledTimes(2);
+  });
+
+  test('debe confirmar y eliminar un proyecto', async () => {
+    renderProjectsPage();
+
+    await screen.findByText('Proyecto Alpha');
+    fireEvent.click(screen.getAllByTitle('Delete')[0]);
+
+    expect(screen.getByText('Confirm Deletion')).toBeInTheDocument();
+    expect(
+      screen.getByText('Are you sure you want to delete project "Proyecto Alpha"?')
+    ).toBeInTheDocument();
+
+    const modal = screen.getByText('Confirm Deletion').closest('.modal-box');
+    fireEvent.click(within(modal).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(projectsApi.deleteProject).toHaveBeenCalledWith(1);
+    });
+
+    expect(projectsApi.fetchProjects).toHaveBeenCalledTimes(2);
+  });
+
+  test('debe cancelar la eliminación de un proyecto', async () => {
+    renderProjectsPage();
+
+    await screen.findByText('Proyecto Alpha');
+    fireEvent.click(screen.getAllByTitle('Delete')[0]);
+    const modal = screen.getByText('Confirm Deletion').closest('.modal-box');
+    fireEvent.click(within(modal).getByRole('button', { name: 'Cancel' }));
+
+    expect(projectsApi.deleteProject).not.toHaveBeenCalled();
+    expect(screen.queryByText('Confirm Deletion')).not.toBeInTheDocument();
+  });
+});

--- a/frontend-reactjs/src/setupTests.js
+++ b/frontend-reactjs/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
Esta solicitud de extracción agrega pruebas unitarias y de integración exhaustivas para la funcionalidad relacionada con proyectos en el backend. Las nuevas pruebas garantizan una cobertura completa tanto del controlador como del repositorio de proyectos, verificando el comportamiento correcto de todas las operaciones CRUD.

**Pruebas del controlador para los endpoints de proyectos:**
- Agrega `ProjectControllerTest` para verificar todos los endpoints principales: recuperación de todos los proyectos, obtención de un proyecto por ID, actualización y eliminación de un proyecto. Estas pruebas utilizan `MockMvc` y simulan el `ProjectService` para aislar la lógica del controlador.

**Pruebas del repositorio para la persistencia de proyectos:**
- Agrega `ProjectRepositoryTest` para verificar la lógica de persistencia del `ProjectRepository`, incluyendo el guardado, la recuperación, la actualización, la eliminación y la verificación de existencia de proyectos. Estas pruebas utilizan una base de datos H2 en memoria para garantizar el aislamiento y la repetibilidad.