### PR TITLE
Refactor Project and Task controllers with ApiPaths and validation

### DIFF
--- a/backend-springboot/src/main/java/com/hasbi/taskmanager/controller/ApiPaths.java
+++ b/backend-springboot/src/main/java/com/hasbi/taskmanager/controller/ApiPaths.java
@@ -1,0 +1,24 @@
+package com.hasbi.taskmanager.controller;
+
+public final class ApiPaths {
+
+    public static final String ID = "id";
+    public static final String PROJECT_ID = "projectId";
+
+    public static final String TASKS = "/tasks";
+    public static final String TASKS_ADD = "/add";
+    public static final String TASKS_BY_PROJECT = "/project/{" + PROJECT_ID + "}";
+    public static final String TASKS_BY_ID = "/{" + ID + "}";
+    public static final String TASKS_UPDATE = "/update/{" + ID + "}";
+    public static final String TASKS_DELETE = "/delete/{" + ID + "}";
+
+    public static final String PROJECTS = "/projects";
+    public static final String PROJECTS_ADD = "/add";
+    public static final String PROJECTS_ALL = "/all";
+    public static final String PROJECTS_BY_ID = "/{" + ID + "}";
+    public static final String PROJECTS_UPDATE = "/update/{" + ID + "}";
+    public static final String PROJECTS_DELETE = "/delete/{" + ID + "}";
+
+    private ApiPaths() {
+    }
+}

--- a/backend-springboot/src/main/java/com/hasbi/taskmanager/controller/ControllerResponseBuilder.java
+++ b/backend-springboot/src/main/java/com/hasbi/taskmanager/controller/ControllerResponseBuilder.java
@@ -1,0 +1,17 @@
+package com.hasbi.taskmanager.controller;
+
+import org.springframework.http.ResponseEntity;
+
+public final class ControllerResponseBuilder {
+
+    private ControllerResponseBuilder() {
+    }
+
+    public static <T> ResponseEntity<T> ok(T body) {
+        return ResponseEntity.ok(body);
+    }
+
+    public static ResponseEntity<Void> noContent() {
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend-springboot/src/main/java/com/hasbi/taskmanager/controller/ProjectController.java
+++ b/backend-springboot/src/main/java/com/hasbi/taskmanager/controller/ProjectController.java
@@ -2,43 +2,45 @@ package com.hasbi.taskmanager.controller;
 
 import com.hasbi.taskmanager.dto.ProjectDto;
 import com.hasbi.taskmanager.service.ProjectService;
-import lombok.AllArgsConstructor;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/projects")
-@AllArgsConstructor
+@RequestMapping(ApiPaths.PROJECTS)
+@RequiredArgsConstructor
 public class ProjectController {
 
-    private ProjectService projectService;
+    private final ProjectService projectService;
 
-    @PostMapping("/add")
-    public ResponseEntity<ProjectDto> createProject(@RequestBody ProjectDto projectDto) {
-        ProjectDto project = projectService.createProject(projectDto);
-        return ResponseEntity.ok(project);
+    @PostMapping(ApiPaths.PROJECTS_ADD)
+    public ResponseEntity<ProjectDto> createProject(@Valid @RequestBody ProjectDto projectDto) {
+        return ControllerResponseBuilder.ok(projectService.createProject(projectDto));
     }
 
-    @GetMapping("/all")
+    @GetMapping(ApiPaths.PROJECTS_ALL)
     public ResponseEntity<List<ProjectDto>> getAllProjects() {
-        return ResponseEntity.ok(projectService.getAllProjects());
+        return ControllerResponseBuilder.ok(projectService.getAllProjects());
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<ProjectDto> getProjectById(@PathVariable Long id) {
-        return ResponseEntity.ok(projectService.getProjectById(id));
+    @GetMapping(ApiPaths.PROJECTS_BY_ID)
+    public ResponseEntity<ProjectDto> getProjectById(@PathVariable(ApiPaths.ID) Long id) {
+        return ControllerResponseBuilder.ok(projectService.getProjectById(id));
     }
 
-    @PutMapping("/update/{id}")
-    public ResponseEntity<ProjectDto> updateProject(@PathVariable Long id, @RequestBody ProjectDto projectDto) {
-        return ResponseEntity.ok(projectService.updateProject(id, projectDto));
+    @PutMapping(ApiPaths.PROJECTS_UPDATE)
+    public ResponseEntity<ProjectDto> updateProject(
+            @PathVariable(ApiPaths.ID) Long id,
+            @Valid @RequestBody ProjectDto projectDto) {
+        return ControllerResponseBuilder.ok(projectService.updateProject(id, projectDto));
     }
 
-    @DeleteMapping("/delete/{id}")
-    public ResponseEntity<Void> deleteProject(@PathVariable Long id) {
+    @DeleteMapping(ApiPaths.PROJECTS_DELETE)
+    public ResponseEntity<Void> deleteProject(@PathVariable(ApiPaths.ID) Long id) {
         projectService.deleteProject(id);
-        return ResponseEntity.noContent().build();
+        return ControllerResponseBuilder.noContent();
     }
 }

--- a/backend-springboot/src/main/java/com/hasbi/taskmanager/controller/TaskController.java
+++ b/backend-springboot/src/main/java/com/hasbi/taskmanager/controller/TaskController.java
@@ -2,43 +2,46 @@ package com.hasbi.taskmanager.controller;
 
 import com.hasbi.taskmanager.dto.TaskDto;
 import com.hasbi.taskmanager.service.TaskService;
-import lombok.AllArgsConstructor;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/tasks")
-@AllArgsConstructor
+@RequestMapping(ApiPaths.TASKS)
+@RequiredArgsConstructor
 public class TaskController {
 
-    private TaskService taskService;
+    private final TaskService taskService;
 
-    @PostMapping("/add")
-    public ResponseEntity<TaskDto> createTask(@RequestBody TaskDto taskDto) {
-        TaskDto created = taskService.createTask(taskDto);
-        return ResponseEntity.ok(created);
+    @PostMapping(ApiPaths.TASKS_ADD)
+    public ResponseEntity<TaskDto> createTask(@Valid @RequestBody TaskDto taskDto) {
+        return ControllerResponseBuilder.ok(taskService.createTask(taskDto));
     }
 
-    @GetMapping("/project/{projectId}")
-    public ResponseEntity<List<TaskDto>> getTasksByProjectId(@PathVariable Long projectId) {
-        return ResponseEntity.ok(taskService.getTasksByProjectId(projectId));
+    @GetMapping(ApiPaths.TASKS_BY_PROJECT)
+    public ResponseEntity<List<TaskDto>> getTasksByProjectId(
+            @PathVariable(ApiPaths.PROJECT_ID) Long projectId) {
+        return ControllerResponseBuilder.ok(taskService.getTasksByProjectId(projectId));
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<TaskDto> getTaskById(@PathVariable Long id) {
-        return ResponseEntity.ok(taskService.getTaskById(id));
+    @GetMapping(ApiPaths.TASKS_BY_ID)
+    public ResponseEntity<TaskDto> getTaskById(@PathVariable(ApiPaths.ID) Long id) {
+        return ControllerResponseBuilder.ok(taskService.getTaskById(id));
     }
 
-    @PutMapping("/update/{id}")
-    public ResponseEntity<TaskDto> updateTask(@PathVariable Long id, @RequestBody TaskDto taskDto) {
-        return ResponseEntity.ok(taskService.updateTask(id, taskDto));
+    @PutMapping(ApiPaths.TASKS_UPDATE)
+    public ResponseEntity<TaskDto> updateTask(
+            @PathVariable(ApiPaths.ID) Long id,
+            @Valid @RequestBody TaskDto taskDto) {
+        return ControllerResponseBuilder.ok(taskService.updateTask(id, taskDto));
     }
 
-    @DeleteMapping("/delete/{id}")
-    public ResponseEntity<Void> deleteTask(@PathVariable Long id) {
+    @DeleteMapping(ApiPaths.TASKS_DELETE)
+    public ResponseEntity<Void> deleteTask(@PathVariable(ApiPaths.ID) Long id) {
         taskService.deleteTask(id);
-        return ResponseEntity.noContent().build();
+        return ControllerResponseBuilder.noContent();
     }
 }

--- a/backend-springboot/src/test/java/com/hasbi/taskmanager/controller/ProjectControllerTest.java
+++ b/backend-springboot/src/test/java/com/hasbi/taskmanager/controller/ProjectControllerTest.java
@@ -42,7 +42,7 @@ class ProjectControllerTest {
         when(projectService.getAllProjects()).thenReturn(List.of(project));
 
         // Act + Assert
-        mockMvc.perform(get("/projects/all"))
+        mockMvc.perform(get(ApiPaths.PROJECTS + ApiPaths.PROJECTS_ALL))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(1))
                 .andExpect(jsonPath("$[0].name").value("Proyecto 1"))
@@ -59,7 +59,7 @@ class ProjectControllerTest {
         when(projectService.getProjectById(1L)).thenReturn(project);
 
         // Act + Assert
-        mockMvc.perform(get("/projects/1"))
+        mockMvc.perform(get(ApiPaths.PROJECTS + "/1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(1))
                 .andExpect(jsonPath("$.name").value("Proyecto 1"))
@@ -78,7 +78,7 @@ class ProjectControllerTest {
                 .thenReturn(response);
 
         // Act + Assert
-        mockMvc.perform(put("/projects/update/1")
+        mockMvc.perform(put(ApiPaths.PROJECTS + "/update/1")
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -95,7 +95,7 @@ class ProjectControllerTest {
         doNothing().when(projectService).deleteProject(1L);
 
         // Act + Assert
-        mockMvc.perform(delete("/projects/delete/1"))
+        mockMvc.perform(delete(ApiPaths.PROJECTS + "/delete/1"))
                 .andExpect(status().isNoContent());
 
         verify(projectService).deleteProject(1L);

--- a/backend-springboot/src/test/java/com/hasbi/taskmanager/controller/TaskControllerTest.java
+++ b/backend-springboot/src/test/java/com/hasbi/taskmanager/controller/TaskControllerTest.java
@@ -58,7 +58,7 @@ class TaskControllerTest {
         when(taskService.createTask(Mockito.any(TaskDto.class))).thenReturn(response);
 
         // Act + Assert
-        mockMvc.perform(post("/tasks/add")
+        mockMvc.perform(post(ApiPaths.TASKS + ApiPaths.TASKS_ADD)
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -87,7 +87,7 @@ class TaskControllerTest {
         when(taskService.getTasksByProjectId(10L)).thenReturn(List.of(taskDto));
 
         // Act + Assert
-        mockMvc.perform(get("/tasks/project/10"))
+        mockMvc.perform(get(ApiPaths.TASKS + "/project/10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(1L))
                 .andExpect(jsonPath("$[0].title").value("Test Task"))
@@ -114,7 +114,7 @@ class TaskControllerTest {
         when(taskService.getTaskById(1L)).thenReturn(taskDto);
 
         // Act + Assert
-        mockMvc.perform(get("/tasks/1"))
+        mockMvc.perform(get(ApiPaths.TASKS + "/1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(1L))
                 .andExpect(jsonPath("$.title").value("Test Task"))
@@ -150,7 +150,7 @@ class TaskControllerTest {
         when(taskService.updateTask(Mockito.eq(1L), Mockito.any(TaskDto.class))).thenReturn(response);
 
         // Act + Assert
-        mockMvc.perform(put("/tasks/update/1")
+        mockMvc.perform(put(ApiPaths.TASKS + "/update/1")
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -167,7 +167,7 @@ class TaskControllerTest {
     @Test
     void shouldDeleteTask() throws Exception {
         // Act + Assert
-        mockMvc.perform(delete("/tasks/delete/1"))
+        mockMvc.perform(delete(ApiPaths.TASKS + "/delete/1"))
                 .andExpect(status().isNoContent());
 
         verify(taskService).deleteTask(1L);


### PR DESCRIPTION
This pull request refactors the controllers in the Spring Boot backend to centralize and standardize API endpoint paths, improve code reuse, and enhance maintainability. It introduces utility classes for API paths and response building, updates controllers to use these utilities, and ensures consistency in both production and test code.

**API endpoint standardization and controller refactor:**

* Added a new `ApiPaths` utility class to define all API endpoint paths as constants, ensuring consistency across the application.
* Updated `TaskController` and `ProjectController` to use the `ApiPaths` constants for endpoint mappings, reducing the risk of typos and making future changes easier. Both controllers now use constructor injection (`@RequiredArgsConstructor`) and mark service dependencies as `final` for immutability.
* Introduced a `ControllerResponseBuilder` utility class to centralize the creation of `ResponseEntity` objects, improving code reuse and readability. Controllers now use this builder for their responses.
* Added validation annotations (`@Valid`) to controller methods accepting DTOs, ensuring input data is validated automatically.
**Test updates for consistency:**

* Refactored all controller tests to use `ApiPaths` constants for endpoint URLs, ensuring tests stay in sync with production code and reducing maintenance overhead. 